### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Moving_Average_Filter/keywords.txt
+++ b/Moving_Average_Filter/keywords.txt
@@ -17,5 +17,5 @@ LowPassFilter	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-average    LITERAL1
-median    LITERAL1
+average	LITERAL1
+median	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords